### PR TITLE
Update TimeoutService.java

### DIFF
--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -665,8 +665,8 @@ public class Connection
 		if (kexTimeout < 0)
 			throw new IllegalArgumentException("kexTimeout must be non-negative!");
 
-		final TimeoutState state = new TimeoutState();
-		final TimeoutService timeoutService = new TimeoutService();		    
+		final TimeoutState state = new TimeoutState():		    
+		final TimeoutService timeoutService = new TimeoutService(hostname);		    
 
 		tm = new TransportManager(hostname, port, sourceAddress);
 		

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -666,6 +666,7 @@ public class Connection
 			throw new IllegalArgumentException("kexTimeout must be non-negative!");
 
 		final TimeoutState state = new TimeoutState();
+		final TimeoutService timeoutService = new TimeoutService();		    
 
 		tm = new TransportManager(hostname, port, sourceAddress);
 		
@@ -713,7 +714,7 @@ public class Connection
 
 					long timeoutHorizont = System.currentTimeMillis() + kexTimeout;
 
-					token = TimeoutService.addTimeoutHandler(timeoutHorizont, timeoutHandler);
+					token = timeoutService.addTimeoutHandler(timeoutHorizont, timeoutHandler);
 				}
 
 				try
@@ -737,7 +738,7 @@ public class Connection
 
 				if (token != null)
 				{
-					TimeoutService.cancelTimeoutHandler(token);
+					timeoutService.cancelTimeoutHandler(token);
 
 					/* Were we too late? */
 

--- a/src/com/trilead/ssh2/util/TimeoutService.java
+++ b/src/com/trilead/ssh2/util/TimeoutService.java
@@ -27,7 +27,7 @@ public class TimeoutService {
 
         public Thread newThread(Runnable r) {
             int threadNumber = count.incrementAndGet();
-            String threadName = "TimeoutService-" + threadNumber;
+            String threadName = "Trilead_TimeoutService_" + threadNumber;
             Thread thread = new Thread(r, threadName);
             thread.setDaemon(true);
             return thread;

--- a/src/com/trilead/ssh2/util/TimeoutService.java
+++ b/src/com/trilead/ssh2/util/TimeoutService.java
@@ -35,6 +35,7 @@ public class TimeoutService {
     };
 
     private final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(20, threadFactory);
+    private static ScheduledFuture<?> scheduledFuture;
 
     public static class TimeoutToken implements Runnable {
         private Runnable handler;
@@ -61,7 +62,7 @@ public class TimeoutService {
         if (delay < 0) {
             delay = 0;
         }
-        scheduler.schedule(token, delay, TimeUnit.MILLISECONDS);
+        scheduledFuture = scheduler.schedule(token, delay, TimeUnit.MILLISECONDS);
         return token;
     }
 
@@ -72,5 +73,6 @@ public class TimeoutService {
      */
     public static final void cancelTimeoutHandler(TimeoutToken token) {
         token.cancelled = true;
+        scheduledFuture.cancel(true);
     }
 }

--- a/src/com/trilead/ssh2/util/TimeoutService.java
+++ b/src/com/trilead/ssh2/util/TimeoutService.java
@@ -21,22 +21,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @version $Id: TimeoutService.java,v 1.1 2007/10/15 12:49:57 cplattne Exp $
  */
 public class TimeoutService {
-
+    
+    
+    private  ScheduledFuture<?> scheduledFuture;
+    private final String hostname;
     private final ThreadFactory threadFactory = new ThreadFactory() {
 
-        private AtomicInteger count = new AtomicInteger();
-
+        @Override
         public Thread newThread(Runnable r) {
-            int threadNumber = count.incrementAndGet();
-            String threadName = "Trilead_TimeoutService_" + threadNumber;
+            
+            String threadName = hostname+"_Trilead_TimeoutService";
             Thread thread = new Thread(r, threadName);
             thread.setDaemon(true);
             return thread;
         }
     };
-    
     private final  ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
-    private  ScheduledFuture<?> scheduledFuture;
+    
+    public TimeoutService(String hostname){
+        this.hostname = hostname;
+    }
+    
+    
 
 
     public class TimeoutToken implements Runnable {

--- a/src/com/trilead/ssh2/util/TimeoutService.java
+++ b/src/com/trilead/ssh2/util/TimeoutService.java
@@ -30,7 +30,7 @@ public class TimeoutService {
         @Override
         public Thread newThread(Runnable r) {
             
-            String threadName = hostname+"_Trilead_TimeoutService";
+            String threadName = "Trilead_TimeoutService_"+hostname;
             Thread thread = new Thread(r, threadName);
             thread.setDaemon(true);
             return thread;


### PR DESCRIPTION
interrupt hanging timeoutservice threads

We can see that after our application finishes we can still see timeoutservice left.
```
TimeoutService-1" #26 daemon prio=5 os_prio=0 cpu=0.95ms elapsed=153134.45s tid=0x00007f804cdaa9b0 nid=0x20 waiting on condition  [0x00007f804c013000]
"TimeoutService-10" #78 daemon prio=5 os_prio=0 cpu=0.20ms elapsed=144280.77s tid=0x00007f804eb2e6c0 nid=0x6d waiting on condition  [0x00007f80484e6000]
"TimeoutService-11" #84 daemon prio=5 os_prio=0 cpu=0.43ms elapsed=144271.51s tid=0x00007f804eb30cb0 nid=0x73 waiting on condition  [0x00007f80494fd000]
"TimeoutService-12" #86 daemon prio=5 os_prio=0 cpu=0.62ms elapsed=144271.30s tid=0x00007f804eb31940 nid=0x75 waiting on condition  [0x00007f8049180000]
"TimeoutService-13" #109 daemon prio=5 os_prio=0 cpu=0.25ms elapsed=86787.79s tid=0x00007f804c163700 nid=0xa0 waiting on condition  [0x00007f804af93000]
"TimeoutService-14" #112 daemon prio=5 os_prio=0 cpu=0.22ms elapsed=86787.46s tid=0x00007f804ed9f9f0 nid=0xa3 waiting on condition  [0x00007f804ad91000]
"TimeoutService-15" #123 daemon prio=5 os_prio=0 cpu=0.31ms elapsed=86783.45s tid=0x00007f804cea1370 nid=0xae waiting on condition  [0x00007f8048f7e000]
"TimeoutService-16" #125 daemon prio=5 os_prio=0 cpu=0.27ms elapsed=86783.15s tid=0x00007f804eab6010 nid=0xb0 waiting on condition  [0x00007f8048760000]
"TimeoutService-17" #130 daemon prio=5 os_prio=0 cpu=0.59ms elapsed=86779.98s tid=0x00007f804eab86a0 nid=0xb5 waiting on condition  [0x00007f80481e3000]
```
The fix attempts to fix this.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

We
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

