### PR TITLE
Add SNTRUP761/X25519 hybrid KEX (sntrup761x25519-sha512) with Bouncy Castle KEM support

### DIFF
--- a/docs/SNTRUP761X25519_DESIGN.md
+++ b/docs/SNTRUP761X25519_DESIGN.md
@@ -1,0 +1,85 @@
+# sntrup761x25519-sha512@openssh.com – implementation summary for Trilead
+
+This document summarizes the Trilead SSH2 implementation of
+`sntrup761x25519-sha512` and `sntrup761x25519-sha512@openssh.com`.
+
+## High-level flow
+
+The algorithm is a **hybrid key exchange**:
+
+1. Use **sntrup761** KEM to produce one shared secret component.
+2. Use **X25519** to produce a second shared secret component.
+3. Combine both components as `SHA-512(sntrup761_secret || x25519_secret)`.
+4. Encode the resulting 64-byte SSH shared secret as an SSH `string`, not as an `mpint`.
+
+The purpose of the hybrid is to keep strong classical security (X25519) while adding
+post-quantum resistance (sntrup761).
+
+## Implementation points in this repository
+
+- `src/com/trilead/ssh2/crypto/dh/KeyEncapsulationMethod.java`
+  - Defines the client-side KEM abstraction used by hybrid KEX implementations.
+- `src/com/trilead/ssh2/crypto/dh/BouncyCastleSntrup761.java`
+  - Wraps Bouncy Castle's SNTRU Prime APIs for key generation and decapsulation.
+- `src/com/trilead/ssh2/crypto/dh/Sntrup761X25519Exchange.java`
+  - Builds the hybrid client public value.
+  - Parses the hybrid server public value.
+  - Computes the 64-byte SHA-512 hybrid shared secret.
+  - Overrides exchange-hash and key-material shared-secret encoding so K is encoded as an SSH string.
+- `src/com/trilead/ssh2/transport/KexManager.java`
+  - Advertises the algorithm in the default KEX list.
+  - Routes negotiated SNTRUP761/X25519 names through the generic KEX packet flow.
+- `src/com/trilead/ssh2/Connection.java`
+  - Provides `setKexAlgorithms(String[])` so tests and advanced callers can force a deterministic
+    KEX preference list.
+
+## Wire format
+
+The SSH messages reuse the ECDH-style packet numbers and byte-string fields:
+
+- Client value `Q_C`: `sntrup761_public || x25519_client_public`
+  - `sntrup761_public`: 1158 bytes
+  - `x25519_client_public`: 32 bytes
+  - total: 1190 bytes
+- Server value `Q_S`: `sntrup761_encapsulation || x25519_server_public`
+  - `sntrup761_encapsulation`: 1039 bytes
+  - `x25519_server_public`: 32 bytes
+  - total: 1071 bytes
+
+The implementation aborts the key exchange if the server value length is not exactly 1071 bytes.
+
+## Apache MINA SSHD implementation as a reference
+
+Apache MINA SSHD is used as a design reference, not copied directly. MINA's implementation is built
+around a KEM abstraction and Bouncy Castle's SNTRU Prime implementation:
+
+- `KeyEncapsulationMethod` separates client-side key generation/secret extraction from server-side
+  encapsulation.
+- `SNTRUP761` delegates key generation, encapsulation, and extraction to Bouncy Castle classes.
+- The client KEX path concatenates the SNTRUP761 public key with the X25519 public key, then combines
+  the SNTRUP761 secret and X25519 secret with the negotiated SHA-512 digest.
+
+Trilead mirrors that architecture with a small local KEM adapter so the transport state machine stays
+focused on SSH packets and the SNTRUP761 primitive remains independently testable.
+
+## OpenSSH flow verification
+
+The repository includes an environment-gated test for OpenSSH interoperability:
+
+```shell
+TRILEAD_OPENSSH_SNTRUP_HOST=127.0.0.1 \
+TRILEAD_OPENSSH_SNTRUP_PORT=2222 \
+mvn -Dtest=com.trilead.ssh2.OpenSshSntrup761X25519FlowTest test
+```
+
+Configure the OpenSSH server to make negotiation deterministic, for example:
+
+```text
+Port 2222
+PasswordAuthentication no
+PubkeyAuthentication yes
+KexAlgorithms sntrup761x25519-sha512@openssh.com
+```
+
+The test forces `sntrup761x25519-sha512@openssh.com`, completes the initial key exchange, and asserts
+that the negotiated KEX algorithm matches the OpenSSH alias.

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.20.6</version>
+            <version>2.0.5</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
             <artifactId>jbcrypt</artifactId>
             <version>1.0.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.84</version>
+        </dependency>
         <dependency>
             <groupId>com.google.crypto.tink</groupId>
             <artifactId>tink</artifactId>

--- a/src/com/trilead/ssh2/Connection.java
+++ b/src/com/trilead/ssh2/Connection.java
@@ -1187,6 +1187,28 @@ public class Connection
 	}
 
 	/**
+	 * Define the set of allowed key exchange algorithms to be used for the following key exchange
+	 * operations.
+	 * <p>
+	 * Unless you know what you are doing, you will never need this. This method is primarily useful
+	 * for interoperability testing against servers configured to offer a single key exchange
+	 * algorithm.
+	 *
+	 * @param algos An array of allowed key exchange algorithms. The entries of the array must be
+	 *              ordered after preference, i.e., the entry at index 0 is the most preferred one.
+	 *              You must specify at least one entry.
+	 */
+	public synchronized void setKexAlgorithms(String[] algos)
+	{
+		if ((algos == null) || (algos.length == 0))
+			throw new IllegalArgumentException();
+
+		algos = removeDuplicates(algos);
+		KexManager.checkKexAlgorithmList(algos);
+		cryptoWishList.kexAlgorithms = algos;
+	}
+
+	/**
 	 * Unless you know what you are doing, you will never need this.
 	 *
 	 * @param ciphers ciphers

--- a/src/com/trilead/ssh2/crypto/KeyMaterial.java
+++ b/src/com/trilead/ssh2/crypto/KeyMaterial.java
@@ -24,6 +24,12 @@ public class KeyMaterial
 	private static byte[] calculateKey(HashForSSH2Types sh, BigInteger K, byte[] H, byte type, byte[] SessionID,
 			int keyLength)
 	{
+		return calculateKey(sh, K.toByteArray(), H, type, SessionID, keyLength);
+	}
+
+	private static byte[] calculateKey(HashForSSH2Types sh, byte[] encodedK, byte[] H, byte type, byte[] SessionID,
+			int keyLength)
+	{
 		byte[] res = new byte[keyLength];
 
 		int dglen = sh.getDigestLength();
@@ -32,7 +38,7 @@ public class KeyMaterial
 		byte[][] tmp = new byte[numRounds][];
 
 		sh.reset();
-		sh.updateBigInt(K);
+		sh.updateByteString(encodedK);
 		sh.updateBytes(H);
 		sh.updateByte(type);
 		sh.updateBytes(SessionID);
@@ -49,7 +55,7 @@ public class KeyMaterial
 
 		for (int i = 1; i < numRounds; i++)
 		{
-			sh.updateBigInt(K);
+			sh.updateByteString(encodedK);
 			sh.updateBytes(H);
 
 			for (int j = 0; j < i; j++)
@@ -70,21 +76,29 @@ public class KeyMaterial
 			int blockSizeCS, int macLengthCS, int keyLengthSC, int blockSizeSC, int macLengthSC)
 			throws IllegalArgumentException
 	{
+		return create(hashType, H, K.toByteArray(), SessionID, keyLengthCS, blockSizeCS, macLengthCS,
+				keyLengthSC, blockSizeSC, macLengthSC);
+	}
+
+	public static KeyMaterial create(String hashType, byte[] H, byte[] encodedK, byte[] SessionID, int keyLengthCS,
+			int blockSizeCS, int macLengthCS, int keyLengthSC, int blockSizeSC, int macLengthSC)
+			throws IllegalArgumentException
+	{
 		KeyMaterial km = new KeyMaterial();
 
 		HashForSSH2Types sh = new HashForSSH2Types(hashType);
 
-		km.initial_iv_client_to_server = calculateKey(sh, K, H, (byte) 'A', SessionID, blockSizeCS);
+		km.initial_iv_client_to_server = calculateKey(sh, encodedK, H, (byte) 'A', SessionID, blockSizeCS);
 
-		km.initial_iv_server_to_client = calculateKey(sh, K, H, (byte) 'B', SessionID, blockSizeSC);
+		km.initial_iv_server_to_client = calculateKey(sh, encodedK, H, (byte) 'B', SessionID, blockSizeSC);
 
-		km.enc_key_client_to_server = calculateKey(sh, K, H, (byte) 'C', SessionID, keyLengthCS);
+		km.enc_key_client_to_server = calculateKey(sh, encodedK, H, (byte) 'C', SessionID, keyLengthCS);
 
-		km.enc_key_server_to_client = calculateKey(sh, K, H, (byte) 'D', SessionID, keyLengthSC);
+		km.enc_key_server_to_client = calculateKey(sh, encodedK, H, (byte) 'D', SessionID, keyLengthSC);
 
-		km.integrity_key_client_to_server = calculateKey(sh, K, H, (byte) 'E', SessionID, macLengthCS);
+		km.integrity_key_client_to_server = calculateKey(sh, encodedK, H, (byte) 'E', SessionID, macLengthCS);
 
-		km.integrity_key_server_to_client = calculateKey(sh, K, H, (byte) 'F', SessionID, macLengthSC);
+		km.integrity_key_server_to_client = calculateKey(sh, encodedK, H, (byte) 'F', SessionID, macLengthSC);
 
 		return km;
 	}

--- a/src/com/trilead/ssh2/crypto/dh/BouncyCastleSntrup761.java
+++ b/src/com/trilead/ssh2/crypto/dh/BouncyCastleSntrup761.java
@@ -1,0 +1,75 @@
+package com.trilead.ssh2.crypto.dh;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKEMExtractor;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKeyGenerationParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeKeyPairGenerator;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimeParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimePrivateKeyParameters;
+import org.bouncycastle.pqc.crypto.ntruprime.SNTRUPrimePublicKeyParameters;
+
+/**
+ * Bouncy Castle backed client-side sntrup761 key encapsulation method.
+ */
+final class BouncyCastleSntrup761 implements KeyEncapsulationMethod {
+	static final int PUBLIC_KEY_SIZE = 1158;
+	static final int ENCAPSULATION_SIZE = 1039;
+	static final int SECRET_SIZE = 32;
+
+	private SNTRUPrimeKEMExtractor extractor;
+	private SNTRUPrimePublicKeyParameters publicKey;
+
+	@Override
+	public void init() throws IOException {
+		try {
+			if (SNTRUPrimeParameters.sntrup761.getSessionKeySize() != SECRET_SIZE * 8) {
+				throw new IOException("Bouncy Castle SNTRUP761 must provide a 256-bit session key");
+			}
+
+			SNTRUPrimeKeyPairGenerator generator = new SNTRUPrimeKeyPairGenerator();
+			generator.init(new SNTRUPrimeKeyGenerationParameters(new SecureRandom(), SNTRUPrimeParameters.sntrup761));
+			AsymmetricCipherKeyPair pair = generator.generateKeyPair();
+			extractor = new SNTRUPrimeKEMExtractor((SNTRUPrimePrivateKeyParameters) pair.getPrivate());
+			publicKey = (SNTRUPrimePublicKeyParameters) pair.getPublic();
+		} catch (RuntimeException e) {
+			throw new IOException("Unable to initialize Bouncy Castle SNTRUP761", e);
+		}
+	}
+
+	@Override
+	public byte[] getPublicKey() {
+		if (publicKey == null) {
+			throw new IllegalStateException("SNTRUP761 KEM is not initialized");
+		}
+		return publicKey.getEncoded();
+	}
+
+	@Override
+	public byte[] extractSecret(byte[] encapsulated) throws IOException {
+		if (extractor == null) {
+			throw new IllegalStateException("SNTRUP761 KEM is not initialized");
+		}
+		if (encapsulated.length != getEncapsulationLength()) {
+			throw new IOException("SNTRUP761 encapsulation has invalid length " + encapsulated.length
+					+ " (expected " + getEncapsulationLength() + ")");
+		}
+		try {
+			byte[] secret = extractor.extractSecret(encapsulated);
+			if (secret.length != SECRET_SIZE) {
+				throw new IOException("SNTRUP761 secret has invalid length " + secret.length
+						+ " (expected " + SECRET_SIZE + ")");
+			}
+			return secret;
+		} catch (RuntimeException e) {
+			throw new IOException("Unable to extract SNTRUP761 shared secret", e);
+		}
+	}
+
+	@Override
+	public int getEncapsulationLength() {
+		return ENCAPSULATION_SIZE;
+	}
+}

--- a/src/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
@@ -29,6 +29,9 @@ public abstract class GenericDhExchange
 	}
 
 	public static GenericDhExchange getInstance(String algo) {
+		if (Sntrup761X25519Exchange.NAME.equals(algo) || Sntrup761X25519Exchange.ALT_NAME.equals(algo)) {
+			return new Sntrup761X25519Exchange();
+		}
 		if (Curve25519Exchange.NAME.equals(algo) || Curve25519Exchange.ALT_NAME.equals(algo)) {
 			return new Curve25519Exchange();
 		}
@@ -63,6 +66,21 @@ public abstract class GenericDhExchange
 			throw new IllegalStateException("Shared secret not yet known, need f first!");
 
 		return sharedSecret;
+	}
+
+	/**
+	 * Returns the SSH wire encoding payload for K before the surrounding string length.
+	 * <p>
+	 * Traditional DH algorithms encode K as an mpint, which is represented by
+	 * {@link BigInteger#toByteArray()}. Some hybrid KEX algorithms override this to encode K as a
+	 * fixed-length SSH string.
+	 * </p>
+	 *
+	 * @return raw K bytes to pass to {@code HashForSSH2Types.updateByteString}.
+	 */
+	public byte[] getKeyMaterialSharedSecret()
+	{
+		return getK().toByteArray();
 	}
 
 	/**

--- a/src/com/trilead/ssh2/crypto/dh/KeyEncapsulationMethod.java
+++ b/src/com/trilead/ssh2/crypto/dh/KeyEncapsulationMethod.java
@@ -1,0 +1,39 @@
+package com.trilead.ssh2.crypto.dh;
+
+import java.io.IOException;
+
+/**
+ * Client-side key encapsulation method used by hybrid SSH key exchanges.
+ */
+interface KeyEncapsulationMethod {
+
+	/**
+	 * Initializes the KEM and generates fresh client key material.
+	 *
+	 * @throws IOException if key generation fails.
+	 */
+	void init() throws IOException;
+
+	/**
+	 * Returns the public key bytes sent as the KEM portion of the SSH client public value.
+	 *
+	 * @return public key bytes.
+	 */
+	byte[] getPublicKey();
+
+	/**
+	 * Extracts the shared KEM secret from the server encapsulation ciphertext.
+	 *
+	 * @param encapsulated server encapsulation ciphertext.
+	 * @return shared KEM secret bytes.
+	 * @throws IOException if the ciphertext is malformed or decapsulation fails.
+	 */
+	byte[] extractSecret(byte[] encapsulated) throws IOException;
+
+	/**
+	 * Returns the exact encapsulation ciphertext length expected from the server.
+	 *
+	 * @return encapsulation length in bytes.
+	 */
+	int getEncapsulationLength();
+}

--- a/src/com/trilead/ssh2/crypto/dh/Sntrup761X25519Exchange.java
+++ b/src/com/trilead/ssh2/crypto/dh/Sntrup761X25519Exchange.java
@@ -1,0 +1,165 @@
+package com.trilead.ssh2.crypto.dh;
+
+import com.google.crypto.tink.subtle.X25519;
+import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+/**
+ * Client-side implementation of the OpenSSH hybrid post-quantum key exchange algorithms:
+ * <ul>
+ *     <li>{@code sntrup761x25519-sha512}</li>
+ *     <li>{@code sntrup761x25519-sha512@openssh.com}</li>
+ * </ul>
+ *
+ * <p>The SSH client value is {@code sntrup761_public || x25519_public}. The server value is
+ * {@code sntrup761_encapsulation || x25519_public}. The SSH shared secret is the 64-byte SHA-512
+ * digest of {@code sntrup761_secret || x25519_secret} and is encoded as an SSH {@code string}, not
+ * an {@code mpint}, when computing the exchange hash and transport keys.</p>
+ */
+public final class Sntrup761X25519Exchange extends GenericDhExchange {
+
+	/** IANA/OpenSSH algorithm name. */
+	public static final String NAME = "sntrup761x25519-sha512";
+
+	/** OpenSSH vendor extension algorithm name. */
+	public static final String ALT_NAME = "sntrup761x25519-sha512@openssh.com";
+
+	private static final int X25519_KEY_SIZE = 32;
+	private static final int CLIENT_PUBLIC_KEY_SIZE = BouncyCastleSntrup761.PUBLIC_KEY_SIZE + X25519_KEY_SIZE;
+	private static final int SERVER_PUBLIC_KEY_SIZE = BouncyCastleSntrup761.ENCAPSULATION_SIZE + X25519_KEY_SIZE;
+
+	private final KeyEncapsulationMethod kem;
+
+	private byte[] clientPrivate;
+	private byte[] clientPublic;
+	private byte[] serverPublic;
+	private byte[] sharedSecretBytes;
+
+	public Sntrup761X25519Exchange() {
+		this(new BouncyCastleSntrup761());
+	}
+
+	Sntrup761X25519Exchange(KeyEncapsulationMethod kem) {
+		this.kem = kem;
+	}
+
+	@Override
+	public void init(String name) throws IOException {
+		if (!NAME.equals(name) && !ALT_NAME.equals(name)) {
+			throw new IllegalArgumentException("Unknown SNTRUP hybrid algorithm " + name);
+		}
+
+		kem.init();
+		clientPrivate = X25519.generatePrivateKey();
+		try {
+			byte[] x25519Public = X25519.publicFromPrivate(clientPrivate);
+			byte[] sntrupPublic = kem.getPublicKey();
+			if (sntrupPublic.length != BouncyCastleSntrup761.PUBLIC_KEY_SIZE) {
+				throw new IOException("SNTRUP761 public key has invalid length " + sntrupPublic.length
+						+ " (expected " + BouncyCastleSntrup761.PUBLIC_KEY_SIZE + ")");
+			}
+			clientPublic = concat(sntrupPublic, x25519Public);
+		} catch (InvalidKeyException e) {
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public byte[] getE() {
+		if (clientPublic == null) {
+			throw new IllegalStateException("SNTRUP761/X25519 exchange is not initialized.");
+		}
+		return clientPublic.clone();
+	}
+
+	@Override
+	protected byte[] getServerE() {
+		if (serverPublic == null) {
+			throw new IllegalStateException("SNTRUP761/X25519 server value is not known.");
+		}
+		return serverPublic.clone();
+	}
+
+	@Override
+	public void setF(byte[] f) throws IOException {
+		if (f.length != SERVER_PUBLIC_KEY_SIZE) {
+			throw new IOException("Server sent invalid SNTRUP761/X25519 key length " + f.length
+					+ " (expected " + SERVER_PUBLIC_KEY_SIZE + ")");
+		}
+
+		serverPublic = f.clone();
+		byte[] encapsulation = Arrays.copyOfRange(f, 0, kem.getEncapsulationLength());
+		byte[] serverX25519Public = Arrays.copyOfRange(f, kem.getEncapsulationLength(), f.length);
+
+		try {
+			byte[] x25519Secret = X25519.computeSharedSecret(clientPrivate, serverX25519Public);
+			int allBytes = 0;
+			for (byte x25519Byte : x25519Secret) {
+				allBytes |= x25519Byte;
+			}
+			if (allBytes == 0) {
+				throw new IOException("Invalid X25519 key computed; all zeroes");
+			}
+
+			sharedSecretBytes = sha512(concat(kem.extractSecret(encapsulation), x25519Secret));
+			sharedSecret = new BigInteger(1, sharedSecretBytes);
+		} catch (InvalidKeyException e) {
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public byte[] calculateH(byte[] clientversion, byte[] serverversion, byte[] clientKexPayload,
+			byte[] serverKexPayload, byte[] hostKey) throws UnsupportedEncodingException {
+		HashForSSH2Types hash = new HashForSSH2Types(getHashAlgo());
+
+		hash.updateByteString(clientversion);
+		hash.updateByteString(serverversion);
+		hash.updateByteString(clientKexPayload);
+		hash.updateByteString(serverKexPayload);
+		hash.updateByteString(hostKey);
+		hash.updateByteString(getE());
+		hash.updateByteString(getServerE());
+		hash.updateByteString(getSharedSecretBytes());
+
+		return hash.getDigest();
+	}
+
+	@Override
+	public byte[] getKeyMaterialSharedSecret() {
+		return getSharedSecretBytes();
+	}
+
+	@Override
+	public String getHashAlgo() {
+		return "SHA-512";
+	}
+
+	private byte[] getSharedSecretBytes() {
+		if (sharedSecretBytes == null) {
+			throw new IllegalStateException("Shared secret not yet known, need f first!");
+		}
+		return sharedSecretBytes.clone();
+	}
+
+	private static byte[] concat(byte[] first, byte[] second) {
+		byte[] result = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, result, first.length, second.length);
+		return result;
+	}
+
+	private static byte[] sha512(byte[] input) throws IOException {
+		try {
+			return MessageDigest.getInstance("SHA-512").digest(input);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException("SHA-512 is not available", e);
+		}
+	}
+}

--- a/src/com/trilead/ssh2/transport/KexManager.java
+++ b/src/com/trilead/ssh2/transport/KexManager.java
@@ -21,6 +21,7 @@ import com.trilead.ssh2.crypto.cipher.BlockCipherFactory;
 import com.trilead.ssh2.crypto.dh.Curve25519Exchange;
 import com.trilead.ssh2.crypto.dh.DhGroupExchange;
 import com.trilead.ssh2.crypto.dh.GenericDhExchange;
+import com.trilead.ssh2.crypto.dh.Sntrup761X25519Exchange;
 import com.trilead.ssh2.crypto.digest.MessageMac;
 import com.trilead.ssh2.log.Logger;
 import com.trilead.ssh2.packets.PacketKexDHInit;
@@ -266,7 +267,8 @@ public class KexManager implements MessageHandler
 			int enc_sc_key_len = BlockCipherFactory.getKeySize(kxs.np.enc_algo_server_to_client);
 			int enc_sc_block_len = BlockCipherFactory.getBlockSize(kxs.np.enc_algo_server_to_client);
 
-			km = KeyMaterial.create(kxs.getHashAlgorithm(), kxs.H, kxs.K, sessionId, enc_cs_key_len, enc_cs_block_len, mac_cs_key_len,
+			byte[] encodedK = kxs.dhx != null ? kxs.dhx.getKeyMaterialSharedSecret() : kxs.K.toByteArray();
+			km = KeyMaterial.create(kxs.getHashAlgorithm(), kxs.H, encodedK, sessionId, enc_cs_key_len, enc_cs_block_len, mac_cs_key_len,
 					enc_sc_key_len, enc_sc_block_len, mac_sc_key_len);
 		}
 		catch (IllegalArgumentException e)
@@ -372,13 +374,24 @@ public class KexManager implements MessageHandler
 	}
 
 
+	/**
+	 * Returns the default, ordered key exchange preference list announced by this client.
+	 * <p>
+	 * Higher-priority entries should appear first. The list starts with the OpenSSH hybrid
+	 * post-quantum SNTRUP761/X25519 algorithm and then falls back to classic finite-field DH, ECDH,
+	 * and Curve25519 algorithms.
+	 * </p>
+	 *
+	 * @return ordered list of supported key exchange algorithm names.
+	 */
 	public static String[] getDefaultKexAlgorithmList()
 	{
-		return new String[] { "diffie-hellman-group-exchange-sha256", "diffie-hellman-group-exchange-sha1",
-				"diffie-hellman-group14-sha1", "diffie-hellman-group1-sha1","ecdh-sha2-nistp256","ecdh-sha2-nistp384","ecdh-sha2-nistp521","curve25519-sha256","curve25519-sha256@libssh.org" };
+		return new String[] { Sntrup761X25519Exchange.NAME, Sntrup761X25519Exchange.ALT_NAME,
+					"diffie-hellman-group-exchange-sha256", "diffie-hellman-group-exchange-sha1",
+					"diffie-hellman-group14-sha1", "diffie-hellman-group1-sha1","ecdh-sha2-nistp256","ecdh-sha2-nistp384","ecdh-sha2-nistp521","curve25519-sha256","curve25519-sha256@libssh.org" };
 	}
 
-	// FIXME this code is not used, the check it makes does not match the implementation in other places.
+	// Keep this list in sync with the KEX implementations that the transport layer can instantiate.
 	public static void checkKexAlgorithmList(String[] algos)
 	{
 		for (String algo : algos) {
@@ -402,6 +415,8 @@ public class KexManager implements MessageHandler
 			if ("ecdh-sha2-nistp521".equals(algo))
 				continue;
 			if (Curve25519Exchange.NAME.equals(algo)||Curve25519Exchange.ALT_NAME.equals(algo))
+				continue;
+			if (Sntrup761X25519Exchange.NAME.equals(algo) || Sntrup761X25519Exchange.ALT_NAME.equals(algo))
 				continue;
 			throw new IllegalArgumentException("Unknown kex algorithm '" + algo + "'");
 		}
@@ -494,6 +509,8 @@ public class KexManager implements MessageHandler
 			}
 
 			if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1")
+					|| kxs.np.kex_algo.equals(Sntrup761X25519Exchange.NAME)
+					|| kxs.np.kex_algo.equals(Sntrup761X25519Exchange.ALT_NAME)
 					|| kxs.np.kex_algo.equals(Curve25519Exchange.NAME)
 					|| kxs.np.kex_algo.equals(Curve25519Exchange.ALT_NAME)
 					|| kxs.np.kex_algo.equals("diffie-hellman-group14-sha1")
@@ -633,6 +650,8 @@ public class KexManager implements MessageHandler
 
 		if (kxs.np.kex_algo.equals("diffie-hellman-group1-sha1")
 				|| kxs.np.kex_algo.equals("diffie-hellman-group14-sha1")
+				|| kxs.np.kex_algo.equals(Sntrup761X25519Exchange.NAME)
+				|| kxs.np.kex_algo.equals(Sntrup761X25519Exchange.ALT_NAME)
 				|| kxs.np.kex_algo.equals("ecdh-sha2-nistp256")
 				|| kxs.np.kex_algo.equals("ecdh-sha2-nistp384")
 				|| kxs.np.kex_algo.equals("ecdh-sha2-nistp521")

--- a/test/com/trilead/ssh2/ConnectionKexAlgorithmTest.java
+++ b/test/com/trilead/ssh2/ConnectionKexAlgorithmTest.java
@@ -1,0 +1,25 @@
+package com.trilead.ssh2;
+
+import com.trilead.ssh2.crypto.dh.Sntrup761X25519Exchange;
+import org.junit.Test;
+
+/**
+ * Unit tests for configuring key exchange preferences on {@link Connection}.
+ */
+public class ConnectionKexAlgorithmTest {
+
+	@Test
+	public void setKexAlgorithmsAcceptsSntrupNamesForExplicitInteropTesting() {
+		Connection connection = new Connection("localhost");
+
+		connection.setKexAlgorithms(new String[] {
+				Sntrup761X25519Exchange.NAME,
+				Sntrup761X25519Exchange.ALT_NAME
+		});
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setKexAlgorithmsRejectsUnknownNames() {
+		new Connection("localhost").setKexAlgorithms(new String[] { "sntrup761x25519-sha512@example.com" });
+	}
+}

--- a/test/com/trilead/ssh2/OpenSshSntrup761X25519FlowTest.java
+++ b/test/com/trilead/ssh2/OpenSshSntrup761X25519FlowTest.java
@@ -1,0 +1,52 @@
+package com.trilead.ssh2;
+
+import com.trilead.ssh2.crypto.dh.Sntrup761X25519Exchange;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Optional end-to-end OpenSSH verification for SNTRUP761/X25519 negotiation.
+ *
+ * <p>This test is skipped unless {@code TRILEAD_OPENSSH_SNTRUP_HOST} is set. The target server
+ * must be configured to offer {@code sntrup761x25519-sha512@openssh.com}, ideally as the only
+ * {@code KexAlgorithms} entry so the flow is deterministic.</p>
+ */
+public class OpenSshSntrup761X25519FlowTest {
+
+	private static final String HOST = "TRILEAD_OPENSSH_SNTRUP_HOST";
+	private static final String PORT = "TRILEAD_OPENSSH_SNTRUP_PORT";
+	private static final int DEFAULT_SSH_PORT = 22;
+
+	@Test
+	public void negotiatesSntrupAgainstOpenSsh() throws IOException {
+		String host = System.getenv(HOST);
+		Assume.assumeTrue("Set " + HOST + " to run the OpenSSH SNTRUP761/X25519 flow test", host != null && !host.isEmpty());
+
+		Connection connection = new Connection(host, getPort());
+		connection.setKexAlgorithms(new String[] { Sntrup761X25519Exchange.ALT_NAME });
+
+		try {
+			ConnectionInfo info = connection.connect(new ServerHostKeyVerifier() {
+				@Override
+				public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey) {
+					return true;
+				}
+			}, 0, 0);
+			assertEquals(Sntrup761X25519Exchange.ALT_NAME, info.keyExchangeAlgorithm);
+		} finally {
+			connection.close();
+		}
+	}
+
+	private static int getPort() {
+		String value = System.getenv(PORT);
+		if (value == null || value.isEmpty()) {
+			return DEFAULT_SSH_PORT;
+		}
+		return Integer.parseInt(value);
+	}
+}

--- a/test/com/trilead/ssh2/crypto/dh/Sntrup761X25519ExchangeTest.java
+++ b/test/com/trilead/ssh2/crypto/dh/Sntrup761X25519ExchangeTest.java
@@ -1,0 +1,123 @@
+package com.trilead.ssh2.crypto.dh;
+
+import com.google.crypto.tink.subtle.X25519;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the SNTRUP761/X25519 hybrid key exchange wiring and shared secret construction.
+ */
+public class Sntrup761X25519ExchangeTest {
+
+	@Test
+	public void getInstanceReturnsSntrupExchangeForStandardName() {
+		GenericDhExchange exchange = GenericDhExchange.getInstance(Sntrup761X25519Exchange.NAME);
+
+		assertTrue(exchange instanceof Sntrup761X25519Exchange);
+	}
+
+	@Test
+	public void getInstanceReturnsSntrupExchangeForOpenSshName() {
+		GenericDhExchange exchange = GenericDhExchange.getInstance(Sntrup761X25519Exchange.ALT_NAME);
+
+		assertTrue(exchange instanceof Sntrup761X25519Exchange);
+	}
+
+	@Test
+	public void getHashAlgoUsesSha512() {
+		Sntrup761X25519Exchange exchange = new Sntrup761X25519Exchange(new FakeKem());
+
+		assertEquals("SHA-512", exchange.getHashAlgo());
+	}
+
+	@Test
+	public void initBuildsClientPublicValueFromSntrupAndX25519PublicKeys() throws IOException {
+		FakeKem kem = new FakeKem();
+		Sntrup761X25519Exchange exchange = new Sntrup761X25519Exchange(kem);
+
+		exchange.init(Sntrup761X25519Exchange.ALT_NAME);
+
+		byte[] clientPublic = exchange.getE();
+		assertEquals(BouncyCastleSntrup761.PUBLIC_KEY_SIZE + Curve25519Exchange.KEY_SIZE, clientPublic.length);
+		assertArrayEquals(kem.publicKey, Arrays.copyOf(clientPublic, BouncyCastleSntrup761.PUBLIC_KEY_SIZE));
+	}
+
+	@Test
+	public void setFComputesStringEncodedSha512HybridSharedSecret() throws Exception {
+		FakeKem kem = new FakeKem();
+		Sntrup761X25519Exchange exchange = new Sntrup761X25519Exchange(kem);
+		exchange.init(Sntrup761X25519Exchange.NAME);
+
+		byte[] serverPrivate = X25519.generatePrivateKey();
+		byte[] serverPublic = X25519.publicFromPrivate(serverPrivate);
+		byte[] clientX25519Public = Arrays.copyOfRange(exchange.getE(), BouncyCastleSntrup761.PUBLIC_KEY_SIZE,
+				exchange.getE().length);
+		byte[] x25519Secret = X25519.computeSharedSecret(serverPrivate, clientX25519Public);
+		byte[] expected = java.security.MessageDigest.getInstance("SHA-512").digest(concat(kem.secret, x25519Secret));
+
+		exchange.setF(concat(kem.encapsulation, serverPublic));
+
+		assertArrayEquals(expected, exchange.getKeyMaterialSharedSecret());
+		assertEquals(64, exchange.getKeyMaterialSharedSecret().length);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void initRejectsUnknownAlgorithmName() throws IOException {
+		new Sntrup761X25519Exchange(new FakeKem()).init("sntrup761x25519-sha512@example.com");
+	}
+
+	@Test(expected = IOException.class)
+	public void setFRejectsWrongServerValueLength() throws IOException {
+		Sntrup761X25519Exchange exchange = new Sntrup761X25519Exchange(new FakeKem());
+		exchange.init(Sntrup761X25519Exchange.NAME);
+
+		exchange.setF(new byte[1]);
+	}
+
+	private static byte[] concat(byte[] first, byte[] second) {
+		byte[] result = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, result, first.length, second.length);
+		return result;
+	}
+
+	private static final class FakeKem implements KeyEncapsulationMethod {
+		private final byte[] publicKey = fill(BouncyCastleSntrup761.PUBLIC_KEY_SIZE, 1);
+		private final byte[] encapsulation = fill(BouncyCastleSntrup761.ENCAPSULATION_SIZE, 2);
+		private final byte[] secret = fill(BouncyCastleSntrup761.SECRET_SIZE, 3);
+
+		@Override
+		public void init() {
+			// No-op.
+		}
+
+		@Override
+		public byte[] getPublicKey() {
+			return publicKey.clone();
+		}
+
+		@Override
+		public byte[] extractSecret(byte[] encapsulated) throws IOException {
+			assertArrayEquals(encapsulation, encapsulated);
+			return secret.clone();
+		}
+
+		@Override
+		public int getEncapsulationLength() {
+			return encapsulation.length;
+		}
+
+		private static byte[] fill(int length, int seed) {
+			byte[] value = new byte[length];
+			for (int i = 0; i < value.length; i++) {
+				value[i] = (byte) (seed + i);
+			}
+			return value;
+		}
+	}
+}

--- a/test/com/trilead/ssh2/transport/KexManagerTest.java
+++ b/test/com/trilead/ssh2/transport/KexManagerTest.java
@@ -4,6 +4,7 @@ import com.trilead.ssh2.DHGexParameters;
 import com.trilead.ssh2.RandomFactory;
 import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.crypto.CryptoWishList;
+import com.trilead.ssh2.crypto.dh.Sntrup761X25519Exchange;
 import com.trilead.ssh2.packets.PacketKexInit;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -318,5 +319,19 @@ public void testNoMatchingLanguages() throws NegotiateException {
 	assertNull("Expected lang_client_to_server to be null", np.lang_client_to_server);
 	assertNull("Expected lang_server_to_client to be null", np.lang_server_to_client);
 }
+
+	@Test
+	public void advertisesSntrupHybridKexByDefault() {
+		assertEquals(Sntrup761X25519Exchange.NAME, KexManager.getDefaultKexAlgorithmList()[0]);
+		assertEquals(Sntrup761X25519Exchange.ALT_NAME, KexManager.getDefaultKexAlgorithmList()[1]);
+	}
+
+	@Test
+	public void checkKexAlgorithmListAcceptsSntrupHybridNames() {
+		KexManager.checkKexAlgorithmList(new String[] {
+				Sntrup761X25519Exchange.NAME,
+				Sntrup761X25519Exchange.ALT_NAME
+		});
+	}
 
 }


### PR DESCRIPTION
### Motivation

- Add OpenSSH-compatible hybrid post-quantum key exchange (`sntrup761x25519-sha512` / `sntrup761x25519-sha512@openssh.com`) to provide X25519 classical security plus SNTRU Prime post-quantum protection. 

### Description

- Implement client-side KEM abstraction and SNTRUP761 adapter with `KeyEncapsulationMethod` and `BouncyCastleSntrup761` backed by Bouncy Castle, and add the hybrid KEX `Sntrup761X25519Exchange` that builds/parses wire values and computes `SHA-512(sntrup_secret || x25519_secret)` encoded as an SSH `string`.
- Add hybrid algorithm support to the transport layer via `GenericDhExchange` instantiation, include the hybrid names in `KexManager.getDefaultKexAlgorithmList()`, and update `KexManager.checkKexAlgorithmList` and routing for the new algorithms.
- Change key material handling to accept a raw byte-array K encoding (string-encoded shared secret) by adding overloaded `KeyMaterial.create` and updating `calculateKey` to accept `byte[] encodedK` so hybrid K is encoded correctly for `H` and derived keys.
- Add `Connection.setKexAlgorithms(String[])` to allow forcing KEX preferences (useful for deterministic interop tests), add Pom dependency on `org.bouncycastle:bcprov-jdk18on:1.84`, and include documentation `docs/SNTRUP761X25519_DESIGN.md` describing flow and an environment-gated OpenSSH interoperability check.

### Testing

- Ran unit tests: `Sntrup761X25519ExchangeTest`, `KexManagerTest`, and `ConnectionKexAlgorithmTest`, and they passed (the OpenSSH flow test `OpenSshSntrup761X25519FlowTest` is environment-gated and is skipped unless `TRILEAD_OPENSSH_SNTRUP_HOST`/`PORT` are set). 
- The test suite was executed with `mvn test` and completed successfully for the unit tests (interop test is optional and skipped when environment variables are not provided).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f883ffbbdc832ebabcd2e3baaf068a)